### PR TITLE
Add user horizon selection and forecast chart

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -20,17 +20,20 @@ def index():
         # 1. Leemos el período seleccionado en el formulario
         selected_period = request.form.get('period_select')
         
-        # 2. Obtenemos los datos de Yahoo Finance para ese período
+        # 2. Leemos cuántos puntos quiere pronosticar el usuario
+        horizon = int(request.form.get('forecast_horizon', 1))
+
+        # 3. Obtenemos los datos de Yahoo Finance para ese período
         df = get_data_from_yahoo(period=selected_period)
-        
-        # 3. Entrenamos los modelos y obtenemos predicciones + métricas
-        metrics_df, forecast_values = train_and_evaluate_all_models(df)
-        
-        # 4. Renderizamos la plantilla con los resultados
+        # 4. Entrenamos los modelos y obtenemos predicciones + métricas
+        metrics_df, forecast_values, future_points = train_and_evaluate_all_models(df, forecast_steps=horizon)
+        # 5. Renderizamos la plantilla con los resultados
         return render_template('index.html',
                                period=selected_period,
                                tables=[metrics_df.to_html(classes='table table-striped', index=False)],
-                               forecast_values=forecast_values
+                               forecast_values=forecast_values,
+                               actual_series=df['Close'].tolist(),
+                               forecast_series=future_points
                                )
     else:
         # Método GET: solo mostramos el formulario vacío
@@ -48,22 +51,22 @@ def get_data_from_yahoo(period='1y'):
     data.reset_index(inplace=True)
     return data
 
-def train_and_evaluate_all_models(df):
+def train_and_evaluate_all_models(df, forecast_steps=1):
     ts = df['Close'].values
     train_data = ts[:-5]
     test_data  = ts[-5:]
     
     # Series de tiempo
-    sarima_metrics, _, sarima_forecast = train_sarima(train_data, test_data)
-    hw_metrics, _, hw_forecast = train_holtwinters(train_data, test_data)
+    sarima_metrics, _, sarima_forecast = train_sarima(train_data, test_data, forecast_steps)
+    hw_metrics, _, hw_forecast = train_holtwinters(train_data, test_data, forecast_steps)
 
     # ML
-    linreg_metrics, _, linreg_forecast = train_linear_regression(train_data, test_data)
-    rf_metrics, _, rf_forecast = train_random_forest(train_data, test_data)
+    linreg_metrics, _, linreg_forecast = train_linear_regression(train_data, test_data, forecast_steps)
+    rf_metrics, _, rf_forecast = train_random_forest(train_data, test_data, forecast_steps)
 
     # Deep Learning
-    rnn_metrics, _, rnn_forecast = train_rnn(train_data, test_data)
-    lstm_metrics, _, lstm_forecast = train_lstm(train_data, test_data)
+    rnn_metrics, _, rnn_forecast = train_rnn(train_data, test_data, forecast_steps)
+    lstm_metrics, _, lstm_forecast = train_lstm(train_data, test_data, forecast_steps)
     
     # Construimos DataFrame de métricas
     metrics_df = pd.DataFrame([
@@ -85,7 +88,7 @@ def train_and_evaluate_all_models(df):
         "LSTM": lstm_forecast
     }
     
-    return metrics_df, forecast_values
+    return metrics_df, forecast_values, sarima_forecast
 
 if __name__ == '__main__':
     # app.run(debug=True)  # Para desarrollo local

--- a/my_forecast_app_v1/models/dl_models.py
+++ b/my_forecast_app_v1/models/dl_models.py
@@ -17,7 +17,7 @@ def prepare_data_dl(series, lag=1):
     X = X.reshape((X.shape[0], 1, X.shape[1]))
     return X, y
 
-def train_rnn(train_data, test_data):
+def train_rnn(train_data, test_data, forecast_steps=1):
     X_train, y_train = prepare_data_dl(train_data)
     
     # Definimos la RNN
@@ -47,19 +47,21 @@ def train_rnn(train_data, test_data):
     rmse = math.sqrt(np.mean((predictions - test_data)**2))
     
     # Forecast siguiente
-    last_test = test_data[-1]
-    next_input = np.array([[last_test]])
-    next_input = next_input.reshape((1,1,1))
-    forecast_next = model.predict(next_input, verbose=0)[0][0]
+    forecast_next = []
+    next_input = np.array([[test_data[-1]]]).reshape((1,1,1))
+    for _ in range(forecast_steps):
+        next_pred = model.predict(next_input, verbose=0)[0][0]
+        forecast_next.append(next_pred)
+        next_input = np.array([[next_pred]]).reshape((1,1,1))
     
     metrics = {
         "Modelo": "RNN",
         "MAE": round(mae, 4),
         "RMSE": round(rmse, 4)
     }
-    return metrics, predictions, float(forecast_next)
+    return metrics, predictions, [float(x) for x in forecast_next]
 
-def train_lstm(train_data, test_data):
+def train_lstm(train_data, test_data, forecast_steps=1):
     X_train, y_train = prepare_data_dl(train_data)
     
     model = Sequential()
@@ -84,13 +86,16 @@ def train_lstm(train_data, test_data):
     mae = np.mean(np.abs(predictions - test_data))
     rmse = math.sqrt(np.mean((predictions - test_data)**2))
     
-    last_test = test_data[-1]
-    next_input = np.array([[last_test]]).reshape((1,1,1))
-    forecast_next = model.predict(next_input, verbose=0)[0][0]
+    forecast_next = []
+    next_input = np.array([[test_data[-1]]]).reshape((1,1,1))
+    for _ in range(forecast_steps):
+        next_pred = model.predict(next_input, verbose=0)[0][0]
+        forecast_next.append(next_pred)
+        next_input = np.array([[next_pred]]).reshape((1,1,1))
     
     metrics = {
         "Modelo": "LSTM",
         "MAE": round(mae, 4),
         "RMSE": round(rmse, 4)
     }
-    return metrics, predictions, float(forecast_next)
+    return metrics, predictions, [float(x) for x in forecast_next]

--- a/my_forecast_app_v1/models/ml_models.py
+++ b/my_forecast_app_v1/models/ml_models.py
@@ -13,7 +13,7 @@ def create_supervised_data(series, lag=1):
     y = df['y'].values         # <-- 1D array
     return X, y
 
-def train_linear_regression(train_data, test_data):
+def train_linear_regression(train_data, test_data, forecast_steps=1):
     X, y = create_supervised_data(train_data, lag=1)
     model = LinearRegression()
     model.fit(X, y)
@@ -32,9 +32,13 @@ def train_linear_regression(train_data, test_data):
     mae = np.mean(np.abs(test_predictions - test_data))
     rmse = math.sqrt(np.mean((test_predictions - test_data) ** 2))
 
-    last_test = test_data[-1]
-    X_next = np.array([last_test]).reshape(1, -1)  # ✅ CORREGIDO
-    forecast_next = model.predict(X_next)[0]
+    forecast_next = []
+    current_input = test_data[-1]
+    for _ in range(forecast_steps):
+        X_next = np.array([current_input]).reshape(1, -1)
+        next_pred = model.predict(X_next)[0]
+        forecast_next.append(next_pred)
+        current_input = next_pred
 
     metrics = {
         "Modelo": "Regresión Lineal",
@@ -42,10 +46,10 @@ def train_linear_regression(train_data, test_data):
         "RMSE": round(rmse, 4)
     }
 
-    return metrics, test_predictions, float(forecast_next)
+    return metrics, test_predictions, [float(x) for x in forecast_next]
 
 
-def train_random_forest(train_data, test_data):
+def train_random_forest(train_data, test_data, forecast_steps=1):
     X, y = create_supervised_data(train_data, lag=1)
     model = RandomForestRegressor(n_estimators=100)
     model.fit(X, y)
@@ -64,9 +68,13 @@ def train_random_forest(train_data, test_data):
     mae = np.mean(np.abs(test_predictions - test_data))
     rmse = math.sqrt(np.mean((test_predictions - test_data) ** 2))
 
-    last_test = test_data[-1]
-    X_next = np.array([last_test]).reshape(1, -1)  # ✅ CORREGIDO
-    forecast_next = model.predict(X_next)[0]
+    forecast_next = []
+    current_input = test_data[-1]
+    for _ in range(forecast_steps):
+        X_next = np.array([current_input]).reshape(1, -1)
+        next_pred = model.predict(X_next)[0]
+        forecast_next.append(next_pred)
+        current_input = next_pred
 
     metrics = {
         "Modelo": "Random Forest",
@@ -74,4 +82,4 @@ def train_random_forest(train_data, test_data):
         "RMSE": round(rmse, 4)
     }
 
-    return metrics, test_predictions, float(forecast_next)
+    return metrics, test_predictions, [float(x) for x in forecast_next]

--- a/my_forecast_app_v1/models/ts_models.py
+++ b/my_forecast_app_v1/models/ts_models.py
@@ -5,7 +5,7 @@ import math
 from statsmodels.tsa.statespace.sarimax import SARIMAX
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
-def train_sarima(train_data, test_data):
+def train_sarima(train_data, test_data, forecast_steps=1):
     # Por simplicidad, usaremos un (1,1,1) y estacionalidad = 12
     # En la práctica, se deben seleccionar p,d,q y parámetros estacionales mediante un proceso de búsqueda.
     model = SARIMAX(train_data, order=(1,1,1), seasonal_order=(1,1,1,12), enforce_stationarity=False, enforce_invertibility=False)
@@ -19,7 +19,8 @@ def train_sarima(train_data, test_data):
     rmse = math.sqrt(np.mean((predictions - test_data)**2))
     
     # Pronóstico del siguiente punto
-    forecast_next = sarima_fit.predict(start=len(train_data)+len(test_data), end=len(train_data)+len(test_data))
+    forecast_next = sarima_fit.predict(start=len(train_data)+len(test_data),
+                                       end=len(train_data)+len(test_data)+forecast_steps-1)
     
     metrics = {
         "Modelo": "SARIMA",
@@ -27,9 +28,9 @@ def train_sarima(train_data, test_data):
         "RMSE": round(rmse, 4)
     }
     
-    return metrics, predictions, float(forecast_next)
+    return metrics, predictions, forecast_next.tolist()
 
-def train_holtwinters(train_data, test_data):
+def train_holtwinters(train_data, test_data, forecast_steps=1):
     # Ver cuántos datos hay en train
     n_train = len(train_data)
     # Solo usar estacionalidad si hay >= 2 ciclos de 12
@@ -48,7 +49,8 @@ def train_holtwinters(train_data, test_data):
     mae = np.mean(np.abs(predictions - test_data))
     rmse = math.sqrt(np.mean((predictions - test_data)**2))
     
-    forecast_next = hw_fit.predict(start=len(train_data)+len(test_data), end=len(train_data)+len(test_data))
+    forecast_next = hw_fit.predict(start=len(train_data)+len(test_data),
+                                   end=len(train_data)+len(test_data)+forecast_steps-1)
     
     metrics = {
         "Modelo": "Holt-Winters",
@@ -56,4 +58,4 @@ def train_holtwinters(train_data, test_data):
         "RMSE": round(rmse, 4)
     }
     
-    return metrics, predictions, float(forecast_next)
+    return metrics, predictions, forecast_next.tolist()

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -18,6 +18,8 @@
                 <option value="2y">2 años</option>
                 <option value="5y">5 años</option>
             </select>
+            <label for="forecast_horizon" class="mt-2">Puntos a pronosticar (1-30):</label>
+            <input type="number" name="forecast_horizon" id="forecast_horizon" class="form-control" value="1" min="1" max="30" style="max-width:150px;" />
             <button type="submit" class="btn btn-primary mt-2">Consultar y pronosticar</button>
         </form>
 
@@ -30,13 +32,35 @@
         {% endif %}
 
         {% if forecast_values %}
-            <h2 class="mt-4">Pronóstico del siguiente punto</h2>
+            <h2 class="mt-4">Pronóstico de los próximos puntos</h2>
             <ul>
             {% for model, fc_val in forecast_values.items() %}
                 <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
             {% endfor %}
             </ul>
+            <canvas id="chart" height="100"></canvas>
         {% endif %}
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    {% if forecast_series %}
+    <script>
+        const actual = {{ actual_series|tojson }};
+        const forecast = {{ forecast_series|tojson }};
+        const labels = Array.from({length: actual.length + forecast.length}, (_,i) => i + 1);
+        const actualData = actual.concat(Array(forecast.length).fill(null));
+        const forecastData = Array(actual.length).fill(null).concat(forecast);
+
+        new Chart(document.getElementById('chart'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {label: 'Precio', data: actualData, borderColor: 'blue', fill:false},
+                    {label: 'Pronóstico', data: forecastData, borderColor: 'red', fill:false}
+                ]
+            }
+        });
+    </script>
+    {% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow user to define forecast horizon
- support multi-step forecasts in all models
- show historical data with future predictions in a chart

## Testing
- `python -m py_compile my_forecast_app_v1/app.py my_forecast_app_v1/models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68422c4aaf8c832f9746dd167769d934