### PR TITLE
Remove forecast horizon option

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -20,18 +20,17 @@ def index():
         # 1. Leemos el período seleccionado en el formulario
         selected_period = request.form.get('period_select')
         
-        # 2. Leemos cuántos puntos quiere pronosticar el usuario
-        horizon = int(request.form.get('forecast_horizon', 1))
         # Porcentaje para testing
         test_percent = float(request.form.get('test_percent', 20))
 
         # 3. Obtenemos los datos de Yahoo Finance para ese período
         df = get_data_from_yahoo(period=selected_period)
         # 4. Entrenamos los modelos y obtenemos predicciones + métricas
+        test_size = max(1, int(len(df) * test_percent / 100))
         metrics_df, forecast_values, pred_series, train_series, test_series = train_and_evaluate_all_models(
             df,
-            forecast_steps=horizon,
-            test_size=max(1, int(len(df) * test_percent / 100))
+            forecast_steps=test_size,
+            test_size=test_size
         )
         # 5. Renderizamos la plantilla con los resultados
         return render_template('index.html',

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -18,8 +18,6 @@
                 <option value="2y">2 años</option>
                 <option value="5y">5 años</option>
             </select>
-            <label for="forecast_horizon" class="mt-2">Puntos a pronosticar (1-30):</label>
-            <input type="number" name="forecast_horizon" id="forecast_horizon" class="form-control" value="1" min="1" max="30" style="max-width:150px;" />
             <label for="test_percent" class="mt-2">Porcentaje para testing:</label>
             <input type="number" name="test_percent" id="test_percent" class="form-control" value="20" min="1" max="80" style="max-width:150px;" />
             <button type="submit" class="btn btn-primary mt-2">Consultar y pronosticar</button>


### PR DESCRIPTION
## Summary
- drop forecast horizon form field
- rely on test percentage for forecasting horizon

## Testing
- `python -m py_compile my_forecast_app_v1/app.py my_forecast_app_v1/models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68423e287280832fb410da0c620bf9f9