### PR TITLE
Add model selection and results view

### DIFF
--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -28,41 +28,39 @@
         {% if tables %}
             <h2 class="mt-4">Resultados de métricas</h2>
             <div>
-                <!-- Muestra el DataFrame de métricas -->
                 {{ tables|safe }}
             </div>
-        {% endif %}
-
-        {% if forecast_values %}
-            <h2 class="mt-4">Pronóstico de los próximos puntos</h2>
-            <ul>
-            {% for model, fc_val in forecast_values.items() %}
-                <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
-            {% endfor %}
-            </ul>
-            <canvas id="chart" height="100"></canvas>
+            <form method="POST" action="/results" class="mt-3">
+                <input type="hidden" name="period_select" value="{{ period }}">
+                <input type="hidden" name="forecast_horizon" value="{{ horizon }}">
+                <input type="hidden" name="test_percent" value="{{ test_percent }}">
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="model_choice" id="model1" value="SARIMA" checked>
+                    <label class="form-check-label" for="model1">SARIMA</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="model_choice" id="model2" value="Holt-Winters">
+                    <label class="form-check-label" for="model2">Holt-Winters</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="model_choice" id="model3" value="Regresión Lineal">
+                    <label class="form-check-label" for="model3">Regresión Lineal</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="model_choice" id="model4" value="Random Forest">
+                    <label class="form-check-label" for="model4">Random Forest</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="model_choice" id="model5" value="RNN">
+                    <label class="form-check-label" for="model5">RNN</label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="model_choice" id="model6" value="LSTM">
+                    <label class="form-check-label" for="model6">LSTM</label>
+                </div>
+                <button type="submit" class="btn btn-success mt-2">Ejecutar</button>
+            </form>
         {% endif %}
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    {% if train_series %}
-    <script>
-        const train = {{ train_series|tojson }};
-        const testReal = {{ test_series|tojson }};
-        const testPred = {{ pred_series|tojson }};
-        const labels = Array.from({length: train.length}, (_,i) => i + 1);
-
-        new Chart(document.getElementById('chart'), {
-            type: 'line',
-            data: {
-                labels: labels,
-                datasets: [
-                    {label: 'Entrenamiento', data: train, borderColor: 'blue', fill:false},
-                    {label: 'Real (test)', data: testReal, borderColor: 'green', fill:false},
-                    {label: 'Predicción (test)', data: testPred, borderColor: 'red', fill:false}
-                ]
-            }
-        });
-    </script>
-    {% endif %}
 </body>
 </html>

--- a/my_forecast_app_v1/templates/results.html
+++ b/my_forecast_app_v1/templates/results.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <title>Resultados del Modelo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" />
+</head>
+<body class="p-4">
+    <div class="container">
+        <h1>Resultados - {{ model }}</h1>
+        <h2 class="mt-4">Valores</h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Entrenamiento</th>
+                    <th>Real</th>
+                    <th>Predicción</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in rows %}
+                <tr>
+                    <td>{{ row[0] }}</td>
+                    <td>{{ row[1] if row[1] is not none else '' }}</td>
+                    <td>{{ row[2] if row[2] is not none else '' }}</td>
+                    <td>{{ row[3] if row[3] is not none else '' }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        <canvas id="chart" height="100"></canvas>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const labels = {{ labels|tojson }};
+        const train = {{ train_series|tojson }};
+        const real = {{ test_series|tojson }};
+        const pred = {{ pred_series|tojson }};
+        new Chart(document.getElementById('chart'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {label: 'Entrenamiento', data: train, borderColor: 'blue', fill:false},
+                    {label: 'Real', data: real, borderColor: 'green', fill:false},
+                    {label: 'Pronosticado', data: pred, borderColor: 'red', fill:false}
+                ]
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add model selection radio buttons to main page
- create new results page to display chosen model's outputs and chart
- implement results endpoint in Flask app

## Testing
- `python -m py_compile my_forecast_app_v1/app.py my_forecast_app_v1/models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684240141874832f9bf0abdc504e3000