### PR TITLE
Add model selection with custom plot view

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, request
+import json
 import yfinance as yf
 import pandas as pd
 from datetime import datetime, timedelta
@@ -10,42 +11,48 @@ from models.dl_models import train_rnn, train_lstm, prepare_data_dl
 
 app = Flask(__name__)
 
-@app.route('/', methods=['GET', 'POST'])
+
+@app.route("/", methods=["GET", "POST"])
 def index():
     """
     En esta vista cargamos la página principal con el combo box para el período.
     Al hacer POST, obtenemos los datos, entrenamos y mostramos métricas.
     """
-    if request.method == 'POST':
+    if request.method == "POST":
         # 1. Leemos el período seleccionado en el formulario
-        selected_period = request.form.get('period_select')
-        
+        selected_period = request.form.get("period_select")
+
         # Porcentaje para testing
-        test_percent = float(request.form.get('test_percent', 20))
+        test_percent = float(request.form.get("test_percent", 20))
 
         # 3. Obtenemos los datos de Yahoo Finance para ese período
         df = get_data_from_yahoo(period=selected_period)
         # 4. Entrenamos los modelos y obtenemos predicciones + métricas
         test_size = max(1, int(len(df) * test_percent / 100))
-        metrics_df, forecast_values, pred_series, train_series, test_series = train_and_evaluate_all_models(
-            df,
-            forecast_steps=test_size,
-            test_size=test_size
+        metrics_df, forecast_values, train_series, test_series, predictions_dict = (
+            train_and_evaluate_all_models(
+                df, forecast_steps=test_size, test_size=test_size
+            )
         )
+
+        dates = df["Date"].dt.strftime("%Y-%m-%d").tolist()
         # 5. Renderizamos la plantilla con los resultados
-        return render_template('index.html',
-                               period=selected_period,
-                               tables=[metrics_df.to_html(classes='table table-striped', index=False)],
-                               forecast_values=forecast_values,
-                               train_series=train_series,
-                               test_series=test_series,
-                               pred_series=pred_series
-                               )
+        return render_template(
+            "index.html",
+            period=selected_period,
+            tables=[metrics_df.to_html(classes="table table-striped", index=False)],
+            forecast_values=forecast_values,
+            train_series=train_series,
+            test_series=test_series,
+            predictions_dict=predictions_dict,
+            dates=dates,
+        )
     else:
         # Método GET: solo mostramos el formulario vacío
-        return render_template('index.html')
+        return render_template("index.html")
 
-def get_data_from_yahoo(period='1y'):
+
+def get_data_from_yahoo(period="1y"):
     """
     Descarga datos de USD/MXN de Yahoo Finance en base a un string de período:
     '1d','5d','1mo','3mo','6mo','1y','2y','5y','10y','ytd','max'
@@ -63,35 +70,50 @@ def get_data_from_yahoo(period='1y'):
     close.columns = ["Date", "Close"]
     return close
 
+
 def train_and_evaluate_all_models(df, forecast_steps=1, test_size=5):
-    ts = df['Close'].values
+    ts = df["Close"].values
     if test_size >= len(ts):
         test_size = max(1, len(ts) // 2)
     train_data = ts[:-test_size]
     test_data = ts[-test_size:]
-    
+
     # Series de tiempo
-    sarima_metrics, sarima_pred, sarima_forecast = train_sarima(train_data, test_data, forecast_steps)
-    hw_metrics, _, hw_forecast = train_holtwinters(train_data, test_data, forecast_steps)
+    sarima_metrics, sarima_pred, sarima_forecast = train_sarima(
+        train_data, test_data, forecast_steps
+    )
+    hw_metrics, hw_pred, hw_forecast = train_holtwinters(
+        train_data, test_data, forecast_steps
+    )
 
     # ML
-    linreg_metrics, _, linreg_forecast = train_linear_regression(train_data, test_data, forecast_steps)
-    rf_metrics, _, rf_forecast = train_random_forest(train_data, test_data, forecast_steps)
+    linreg_metrics, linreg_pred, linreg_forecast = train_linear_regression(
+        train_data, test_data, forecast_steps
+    )
+    rf_metrics, rf_pred, rf_forecast = train_random_forest(
+        train_data, test_data, forecast_steps
+    )
 
     # Deep Learning
-    rnn_metrics, _, rnn_forecast = train_rnn(train_data, test_data, forecast_steps)
-    lstm_metrics, _, lstm_forecast = train_lstm(train_data, test_data, forecast_steps)
-    
+    rnn_metrics, rnn_pred, rnn_forecast = train_rnn(
+        train_data, test_data, forecast_steps
+    )
+    lstm_metrics, lstm_pred, lstm_forecast = train_lstm(
+        train_data, test_data, forecast_steps
+    )
+
     # Construimos DataFrame de métricas
-    metrics_df = pd.DataFrame([
-        sarima_metrics,
-        hw_metrics,
-        linreg_metrics,
-        rf_metrics,
-        rnn_metrics,
-        lstm_metrics
-    ])
-    
+    metrics_df = pd.DataFrame(
+        [
+            sarima_metrics,
+            hw_metrics,
+            linreg_metrics,
+            rf_metrics,
+            rnn_metrics,
+            lstm_metrics,
+        ]
+    )
+
     # Forecast "del siguiente punto" (por simplicidad tomamos el forecast devuelto)
     forecast_values = {
         "SARIMA": sarima_forecast,
@@ -99,15 +121,42 @@ def train_and_evaluate_all_models(df, forecast_steps=1, test_size=5):
         "Regresión Lineal": linreg_forecast,
         "Random Forest": rf_forecast,
         "RNN": rnn_forecast,
-        "LSTM": lstm_forecast
+        "LSTM": lstm_forecast,
     }
-    
+
     train_series = train_data.tolist() + [None] * len(test_data)
     test_series = [None] * len(train_data) + test_data.tolist()
-    pred_series = [None] * len(train_data) + sarima_pred.tolist()
 
-    return metrics_df, forecast_values, pred_series, train_series, test_series
+    predictions_dict = {
+        "SARIMA": [None] * len(train_data) + sarima_pred.tolist(),
+        "Holt-Winters": [None] * len(train_data) + hw_pred.tolist(),
+        "Regresión Lineal": [None] * len(train_data) + linreg_pred.tolist(),
+        "Random Forest": [None] * len(train_data) + rf_pred.tolist(),
+        "RNN": [None] * len(train_data) + rnn_pred.tolist(),
+        "LSTM": [None] * len(train_data) + lstm_pred.tolist(),
+    }
 
-if __name__ == '__main__':
+    return metrics_df, forecast_values, train_series, test_series, predictions_dict
+
+
+@app.route("/plot", methods=["POST"])
+def plot():
+    model_name = request.form.get("model_choice")
+    train_series = json.loads(request.form.get("train_series"))
+    test_series = json.loads(request.form.get("test_series"))
+    dates = json.loads(request.form.get("dates"))
+    pred_series = json.loads(request.form.get(f"pred_{model_name}"))
+
+    return render_template(
+        "plot.html",
+        model_name=model_name,
+        train_series=train_series,
+        test_series=test_series,
+        pred_series=pred_series,
+        dates=dates,
+    )
+
+
+if __name__ == "__main__":
     # app.run(debug=True)  # Para desarrollo local
-    app.run(host='0.0.0.0', port=8080)  # Ajusta el puerto si es necesario
+    app.run(host="0.0.0.0", port=8080)  # Ajusta el puerto si es necesario

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -38,29 +38,28 @@
                 <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
             {% endfor %}
             </ul>
-            <canvas id="chart" height="100"></canvas>
+        {% endif %}
+
+        {% if tables %}
+        <form method="POST" action="{{ url_for('plot') }}" target="_blank" class="mt-4">
+            <p>Selecciona el modelo que prefieras:</p>
+            {% for model in predictions_dict.keys() %}
+            <div class="form-check">
+                <input class="form-check-input" type="radio" name="model_choice" id="rb_{{ loop.index }}" value="{{ model }}" {% if loop.first %}checked{% endif %}>
+                <label class="form-check-label" for="rb_{{ loop.index }}">{{ model }}</label>
+            </div>
+            {% endfor %}
+
+            <input type="hidden" name="train_series" value='{{ train_series|tojson }}'>
+            <input type="hidden" name="test_series" value='{{ test_series|tojson }}'>
+            <input type="hidden" name="dates" value='{{ dates|tojson }}'>
+            {% for model, preds in predictions_dict.items() %}
+            <input type="hidden" name="pred_{{ model }}" value='{{ preds|tojson }}'>
+            {% endfor %}
+
+            <button type="submit" class="btn btn-success mt-2">Ejecutar</button>
+        </form>
         {% endif %}
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    {% if train_series %}
-    <script>
-        const train = {{ train_series|tojson }};
-        const testReal = {{ test_series|tojson }};
-        const testPred = {{ pred_series|tojson }};
-        const labels = Array.from({length: train.length}, (_,i) => i + 1);
-
-        new Chart(document.getElementById('chart'), {
-            type: 'line',
-            data: {
-                labels: labels,
-                datasets: [
-                    {label: 'Entrenamiento', data: train, borderColor: 'blue', fill:false},
-                    {label: 'Real (test)', data: testReal, borderColor: 'green', fill:false},
-                    {label: 'Predicción (test)', data: testPred, borderColor: 'red', fill:false}
-                ]
-            }
-        });
-    </script>
-    {% endif %}
 </body>
 </html>

--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8" />
+    <title>Resultado del Modelo</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" />
+</head>
+<body class="p-4">
+    <div class="container">
+        <h1>Modelo seleccionado: {{ model_name }}</h1>
+        <h3 class="mt-4">Series de valores</h3>
+        <p><strong>Entrenamiento:</strong> {{ train_series }}</p>
+        <p><strong>Reales (test):</strong> {{ test_series }}</p>
+        <p><strong>Pronosticados:</strong> {{ pred_series }}</p>
+        <canvas id="chart" height="100"></canvas>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        const labels = {{ dates|tojson }};
+        const train = {{ train_series|tojson }};
+        const testReal = {{ test_series|tojson }};
+        const testPred = {{ pred_series|tojson }};
+
+        new Chart(document.getElementById('chart'), {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [
+                    {label: 'Entrenamiento', data: train, borderColor: 'blue', fill:false},
+                    {label: 'Real (test)', data: testReal, borderColor: 'green', fill:false},
+                    {label: 'Pronóstico', data: testPred, borderColor: 'red', fill:false}
+                ]
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- update training routine to keep predictions for each model
- let user select preferred model via radio buttons
- add `/plot` route and new template to display chart and series for chosen model

## Testing
- `pytest -q`
- `python -m py_compile my_forecast_app_v1/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684244dd8504832f9ccea5e7d2c04d3b