### PR TITLE
Add .dockerignore

### DIFF
--- a/my_forecast_app_v1/.dockerignore
+++ b/my_forecast_app_v1/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore Git directory
+.git
+
+# Byte-compiled / cache files
+__pycache__/
+*.py[cod]
+
+# Other
+*.log


### PR DESCRIPTION
## Summary
- add `.dockerignore` to avoid git/pycache/pyc during image builds

## Testing
- `docker --version`
- `docker build -t myforecast:v1 my_forecast_app_v1` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6842539b668c832f9a64fd9b07dd16c2