### PR TITLE
Improve metrics table layout

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -55,7 +55,10 @@ def index():
             metrics_df.style
             .apply(highlight_best, axis=1)
             .hide(axis="index")
-            .to_html(classes="table table-striped", table_id="metrics-table")
+            .to_html(
+                classes="table table-striped table-bordered table-hover table-sm text-center",
+                table_id="metrics-table",
+            )
         )
         return render_template(
             "index.html",

--- a/my_forecast_app_v1/static/css/style.css
+++ b/my_forecast_app_v1/static/css/style.css
@@ -8,3 +8,14 @@ body {
     border-radius: 8px;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
+
+#metrics-table {
+    border-collapse: collapse;
+    margin-top: 10px;
+}
+
+#metrics-table th, #metrics-table td {
+    border: 1px solid #dee2e6;
+    padding: 8px;
+    text-align: center;
+}

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -27,7 +27,7 @@
 
         {% if metrics_table %}
             <h2 class="mt-4">Resultados de métricas</h2>
-            <div>
+            <div class="table-responsive">
                 <!-- Muestra el DataFrame de métricas -->
                 {{ metrics_table|safe }}
             </div>


### PR DESCRIPTION
## Summary
- show metrics table in responsive container
- add CSS rules for borders and padding
- add Bootstrap classes when creating HTML for the table

## Testing
- `python -m py_compile my_forecast_app_v1/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685e3c9f0850832fb65386ce37e1b43e