### PR TITLE
Add Yahoo Finance period options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,24 @@ Antes de poder construir o desplegar la aplicación asegúrate de tener:
    python app.py
    ```
 
-   La aplicación quedará disponible en `http://localhost:8080`.
+
+    La aplicación quedará disponible en `http://localhost:8080`.
+
+## Períodos disponibles
+
+Al iniciar la aplicación podrás elegir el período de datos descargados desde Yahoo Finance. Las opciones son:
+
+- `1d`
+- `5d`
+- `1mo`
+- `3mo`
+- `6mo`
+- `1y`
+- `ytd`
+- `2y`
+- `5y`
+- `10y`
+- `max`
 
 ## Construir la imagen con Docker
 

--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -77,8 +77,9 @@ def index():
 
 def get_data_from_yahoo(period="1y"):
     """
-    Descarga datos de USD/MXN de Yahoo Finance en base a un string de período:
-    '1d','5d','1mo','3mo','6mo','1y','2y','5y','10y','ytd','max'
+    Descarga datos de USD/MXN de Yahoo Finance en base a un string de período.
+    Periodos válidos: '1d', '5d', '1mo', '3mo', '6mo', '1y', 'ytd', '2y',
+    '5y', '10y' y 'max'.
     """
     ticker = "MXN=X"  # El par USD/MXN en Yahoo Finance se identifica como "MXN=X"
     data = yf.download(ticker, period=period, interval="1d")

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -13,12 +13,17 @@
         <form method="POST">
             <label for="period_select">Selecciona el periodo:</label>
             <select name="period_select" id="period_select" class="form-select" style="max-width:300px;">
+                <option value="1d">1 día</option>
+                <option value="5d">5 días</option>
                 <option value="1mo">1 mes</option>
                 <option value="3mo">3 meses</option>
                 <option value="6mo">6 meses</option>
                 <option value="1y">1 año</option>
+                <option value="ytd">Año en curso</option>
                 <option value="2y">2 años</option>
                 <option value="5y">5 años</option>
+                <option value="10y">10 años</option>
+                <option value="max">Máx</option>
             </select>
             <label for="test_percent" class="mt-2">Porcentaje para testing:</label>
             <input type="number" name="test_percent" id="test_percent" class="form-control" value="20" min="1" max="80" style="max-width:150px;" />


### PR DESCRIPTION
## Summary
- allow selecting all available Yahoo Finance periods in the web UI
- document the available periods in the README
- clarify valid periods in the helper docstring

## Testing
- `python -m py_compile my_forecast_app_v1/app.py my_forecast_app_v1/models/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685e40e2becc832f8ee36ae74cc09ba3