### PR TITLE
Format MAPE as percentage

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -46,6 +46,9 @@ def index():
         })
         best_idx = ranking.mean(axis=1).idxmin()
 
+        # Formatear MAPE como porcentaje con símbolo %
+        metrics_df["MAPE"] = metrics_df["MAPE"].apply(lambda x: f"{x:.2f}%")
+
         def highlight_best(row):
             return ["background-color: gold"] * len(row) if row.name == best_idx else [""] * len(row)
 


### PR DESCRIPTION
## Summary
- Display MAPE metrics as human-readable percentages with a percent sign in the app dashboard.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b66ed9df7c832fbf6ec367dd4d7b65