### PR TITLE
Improve metrics table borders

### DIFF
--- a/my_forecast_app_v1/static/css/style.css
+++ b/my_forecast_app_v1/static/css/style.css
@@ -12,6 +12,7 @@ body {
 #metrics-table {
     border-collapse: collapse;
     margin-top: 10px;
+    border: 1px solid #dee2e6;
 }
 
 #metrics-table th, #metrics-table td {

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <title>Pronóstico USD/MXN</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.1.3/dist/flatly/bootstrap.min.css" />
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
     <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css" />
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
 </head>
 <body class="p-4">
     <div class="container container-box">


### PR DESCRIPTION
## Summary
- Load custom styles after DataTables stylesheet
- Add table and cell borders for metrics results

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b67295ba64832fa923dfa71de5a4d1