### PR TITLE
Format value series display and remove None

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -68,11 +68,22 @@ def index():
                 table_id="metrics-table",
             )
         )
+
+        def format_forecast(vals):
+            """Return a comma-separated string with two-decimal values."""
+            try:
+                return ", ".join(f"{v:.2f}" for v in vals if v is not None)
+            except TypeError:
+                return f"{vals:.2f}" if vals is not None else ""
+
+        formatted_forecasts = {
+            model: format_forecast(vals) for model, vals in forecast_values.items()
+        }
         return render_template(
             "index.html",
             period=selected_period,
             metrics_table=metrics_table,
-            forecast_values=forecast_values,
+            forecast_values=formatted_forecasts,
             train_series=train_series,
             test_series=test_series,
             predictions_dict=predictions_dict,
@@ -179,6 +190,13 @@ def plot():
     dates = json.loads(request.form.get("dates"))
     pred_series = json.loads(request.form.get(f"pred_{model_name}"))
 
+    def format_series(series):
+        return ", ".join(f"{x:.2f}" for x in series if x is not None)
+
+    train_display = format_series(train_series)
+    test_display = format_series(test_series)
+    pred_display = format_series(pred_series)
+
     return render_template(
         "plot.html",
         model_name=model_name,
@@ -186,6 +204,9 @@ def plot():
         test_series=test_series,
         pred_series=pred_series,
         dates=dates,
+        train_display=train_display,
+        test_display=test_display,
+        pred_display=pred_display,
     )
 
 

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -40,6 +40,7 @@
 
         {% if forecast_values %}
             <h2 class="mt-4">Pronóstico de los próximos puntos</h2>
+            <!-- forecast_values already holds comma-separated strings rounded to two decimals -->
             <ul>
             {% for model, fc_val in forecast_values.items() %}
                 <li><strong>{{ model }}:</strong> {{ fc_val }}</li>

--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -10,9 +10,9 @@
     <div class="container container-box">
         <h1>Modelo seleccionado: {{ model_name }}</h1>
         <h3 class="mt-4">Series de valores</h3>
-        <p><strong>Entrenamiento:</strong> {{ train_series }}</p>
-        <p><strong>Reales (test):</strong> {{ test_series }}</p>
-        <p><strong>Pronosticados:</strong> {{ pred_series }}</p>
+        <p><strong>Entrenamiento:</strong> {{ train_display }}</p>
+        <p><strong>Reales (test):</strong> {{ test_display }}</p>
+        <p><strong>Pronosticados:</strong> {{ pred_display }}</p>
         <canvas id="chart" height="100"></canvas>
     </div>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>


### PR DESCRIPTION
## Summary
- Format forecast values into comma-separated two-decimal strings before rendering.
- Display formatted forecast strings in the index template.
- Avoid double-formatting already formatted forecast strings in the index page.

## Testing
- `python -m py_compile my_forecast_app_v1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b676a94258832f9c61ace618c69426