### PR TITLE
Fix forecast value formatting

### DIFF
--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -43,7 +43,7 @@
             <!-- forecast_values already holds comma-separated strings rounded to two decimals -->
             <ul>
             {% for model, fc_val in forecast_values.items() %}
-                <li><strong>{{ model }}:</strong> {{ "%.2f"|format(fc_val) }}</li>
+                <li><strong>{{ model }}:</strong> {{ fc_val }}</li>
             {% endfor %}
             </ul>
         {% endif %}


### PR DESCRIPTION
## Summary
- Fix display of forecast values by removing redundant numeric formatting in template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b67b4e620c832fbd2ce3e75b463f9e