### PR TITLE
Add border styling to metrics table

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -63,8 +63,23 @@ def index():
             .apply(highlight_best, axis=1)
             .format(format_dict)
             .hide(axis="index")
+            .set_table_styles(
+                [
+                    {
+                        "selector": "",
+                        "props": [
+                            ("border", "1px solid #000"),
+                            ("border-collapse", "collapse"),
+                        ],
+                    },
+                    {
+                        "selector": "th, td",
+                        "props": [("border", "1px solid #000")],
+                    },
+                ]
+            )
             .to_html(
-                classes="table table-striped table-bordered table-hover table-sm text-center",
+                classes="table table-striped table-hover table-sm text-center",
                 table_id="metrics-table",
             )
         )

--- a/my_forecast_app_v1/static/css/style.css
+++ b/my_forecast_app_v1/static/css/style.css
@@ -12,20 +12,14 @@ body {
 #metrics-table {
     border-collapse: collapse;
     margin-top: 10px;
-    border: 1px solid #000;
 }
 
 #metrics-table th, #metrics-table td {
-    border: 1px solid #000;
     padding: 8px;
+    text-align: center;
 }
 
 #metrics-table th {
-    text-align: center;
     color: #000;
     font-weight: bold;
-}
-
-#metrics-table td {
-    text-align: center;
 }


### PR DESCRIPTION
## Summary
- Style metrics table rows and headers with explicit borders so table edges appear in the UI.
- Simplify CSS for `#metrics-table` to rely on inlined Styler borders while preserving layout.

## Testing
- `python -m py_compile my_forecast_app_v1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b680eef3a4832fa0f9ee325d145321