### PR TITLE
Convertir MAPE a porcentaje

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -172,6 +172,9 @@ def train_and_evaluate_all_models(df, forecast_steps=1, test_size=5):
         ]
     )
 
+    # Expresar el MAPE como porcentaje
+    metrics_df["MAPE"] = metrics_df["MAPE"] * 100
+
     # Forecast "del siguiente punto" (por simplicidad tomamos el forecast devuelto)
     forecast_values = {
         "SARIMA": sarima_forecast,


### PR DESCRIPTION
## Summary
- Multiplica el valor de MAPE por 100 antes de renderizar resultados para expresar el error como porcentaje

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b682db0954832f9b24e02cfa2adb2a