### PR TITLE
Add spacing between metrics table columns

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -69,7 +69,8 @@ def index():
                         "selector": "",
                         "props": [
                             ("border", "1px solid #000"),
-                            ("border-collapse", "collapse"),
+                            ("border-collapse", "separate"),
+                            ("border-spacing", "10px 0"),
                         ],
                     },
                     {

--- a/my_forecast_app_v1/static/css/style.css
+++ b/my_forecast_app_v1/static/css/style.css
@@ -10,12 +10,13 @@ body {
 }
 
 #metrics-table {
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 10px 0;
     margin-top: 10px;
 }
 
 #metrics-table th, #metrics-table td {
-    padding: 8px;
+    padding: 8px 12px;
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- separate table columns and add horizontal spacing in metrics table styling
- widen cell padding in metrics table to avoid cramped values

## Testing
- `python -m py_compile my_forecast_app_v1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b68492ebb4832fb0f969a472491e37