### PR TITLE
Add button to save model info to GCS

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -1,8 +1,10 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, jsonify
 import json
+import os
 import yfinance as yf
 import pandas as pd
 from datetime import datetime, timedelta
+from google.cloud import storage
 
 # Importamos funciones de modelado (veremos detalles luego)
 from models.ts_models import train_sarima, train_holtwinters
@@ -227,6 +229,24 @@ def plot():
         test_display=test_display,
         pred_display=pred_display,
     )
+
+
+@app.route("/save", methods=["POST"])
+def save_to_gcs():
+    data = request.get_json()
+    bucket_name = os.environ.get("GCS_BUCKET_NAME")
+    if not bucket_name:
+        return jsonify({"message": "GCS_BUCKET_NAME not configured"}), 500
+
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    model_name = data.get("model_name", "model")
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    blob_name = f"{model_name}_{timestamp}.json"
+    blob = bucket.blob(blob_name)
+    blob.upload_from_string(json.dumps(data), content_type="application/json")
+
+    return jsonify({"message": "Data saved to GCS", "blob": blob_name})
 
 
 if __name__ == "__main__":

--- a/my_forecast_app_v1/requirements.txt
+++ b/my_forecast_app_v1/requirements.txt
@@ -5,5 +5,6 @@ pandas==1.5.3
 numpy==1.23.5
 scikit-learn==1.2.2
 statsmodels==0.13.5
-tensorflow==2.12.0  
+tensorflow==2.12.0
 gunicorn==21.2.0
+google-cloud-storage==2.14.0

--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -14,6 +14,7 @@
         <p><strong>Reales (test):</strong> {{ test_display }}</p>
         <p><strong>Pronosticados:</strong> {{ pred_display }}</p>
         <canvas id="chart" height="100"></canvas>
+        <button id="save-btn" class="btn btn-primary mt-3">Guardar en GCP</button>
     </div>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
@@ -22,6 +23,7 @@
         const train = {{ train_series|tojson }};
         const testReal = {{ test_series|tojson }};
         const testPred = {{ pred_series|tojson }};
+        const modelName = {{ model_name|tojson }};
 
         new Chart(document.getElementById('chart'), {
             type: 'line',
@@ -33,6 +35,23 @@
                     {label: 'Pronóstico', data: testPred, borderColor: 'red', fill:false}
                 ]
             }
+        });
+
+        document.getElementById('save-btn').addEventListener('click', function() {
+            fetch('/save', {
+                method: 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body: JSON.stringify({
+                    model_name: modelName,
+                    train_series: train,
+                    test_series: testReal,
+                    pred_series: testPred,
+                    dates: labels
+                })
+            })
+            .then(resp => resp.json())
+            .then(data => alert(data.message))
+            .catch(err => console.error(err));
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- Add Google Cloud Storage dependency
- Add `/save` endpoint to upload model data to GCS bucket
- Add "Guardar en GCP" button and JavaScript fetch in plot view

## Testing
- `pytest`
- `python -m py_compile my_forecast_app_v1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6878f975c832fb3114032e7996ee5