### PR TITLE
Handle empty datasets in SARIMA and Holt-Winters models

### DIFF
--- a/my_forecast_app_v1/models/ts_models.py
+++ b/my_forecast_app_v1/models/ts_models.py
@@ -8,6 +8,15 @@ from statsmodels.tsa.holtwinters import ExponentialSmoothing
 def train_sarima(train_data, test_data, forecast_steps=1):
     # Por simplicidad, usaremos un (1,1,1) y estacionalidad = 12
     # En la práctica, se deben seleccionar p,d,q y parámetros estacionales mediante un proceso de búsqueda.
+    if len(train_data) == 0 or len(test_data) == 0:
+        metrics = {
+            "Modelo": "SARIMA",
+            "MAE": float("nan"),
+            "RMSE": float("nan"),
+            "MAPE": float("nan"),
+            "R^2": float("nan"),
+        }
+        return metrics, np.array([]), [None] * forecast_steps
     model = SARIMAX(train_data, order=(1,1,1), seasonal_order=(1,1,1,12), enforce_stationarity=False, enforce_invertibility=False)
     sarima_fit = model.fit(disp=False)
     
@@ -41,6 +50,15 @@ def train_sarima(train_data, test_data, forecast_steps=1):
     return metrics, predictions, forecast_next.tolist()
 
 def train_holtwinters(train_data, test_data, forecast_steps=1):
+    if len(train_data) == 0 or len(test_data) == 0:
+        metrics = {
+            "Modelo": "Holt-Winters",
+            "MAE": float("nan"),
+            "RMSE": float("nan"),
+            "MAPE": float("nan"),
+            "R^2": float("nan"),
+        }
+        return metrics, np.array([]), [None] * forecast_steps
     # Ver cuántos datos hay en train
     n_train = len(train_data)
     # Solo usar estacionalidad si hay >= 2 ciclos de 12


### PR DESCRIPTION
## Summary
- Guard against empty train/test data in SARIMA and Holt-Winters training
- Return NaN metrics and placeholder forecasts when data is insufficient

## Testing
- `python -m py_compile my_forecast_app_v1/models/ts_models.py`
- `python - <<'PY'
import numpy as np
from my_forecast_app_v1.models.ts_models import train_sarima, train_holtwinters
train = np.arange(10)
test = np.arange(5)
metrics, preds, forecast = train_sarima(train, test)
metrics_empty, preds_empty, forecast_empty = train_sarima(np.array([]), np.array([]))
metrics_hw, preds_hw, forecast_hw = train_holtwinters(train, test)
metrics_hw_empty, preds_hw_empty, forecast_hw_empty = train_holtwinters(np.array([]), np.array([]))
print('sarima metrics', metrics)
print('sarima empty', metrics_empty, preds_empty, forecast_empty)
print('holt metrics', metrics_hw)
print('holt empty', metrics_hw_empty, preds_hw_empty, forecast_hw_empty)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b774ea59b4832f9857b62e4a540262