### PR TITLE
Reapply spacing between table columns

### DIFF
--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -69,7 +69,8 @@ def index():
                         "selector": "",
                         "props": [
                             ("border", "1px solid #000"),
-                            ("border-collapse", "collapse"),
+                            ("border-collapse", "separate"),
+                            ("border-spacing", "10px 0"),
                         ],
                     },
                     {

--- a/my_forecast_app_v1/static/css/style.css
+++ b/my_forecast_app_v1/static/css/style.css
@@ -10,12 +10,13 @@ body {
 }
 
 #metrics-table {
-    border-collapse: collapse;
+    border-collapse: separate;
+    border-spacing: 10px 0;
     margin-top: 10px;
 }
 
 #metrics-table th, #metrics-table td {
-    padding: 8px;
+    padding: 8px 12px;
     text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- Restore separate border collapse and spacing for metrics table styling
- Add padding to metrics table cells in CSS for clearer column separation

## Testing
- `python -m py_compile my_forecast_app_v1/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b784b769bc832f9949c23fcc34d06c