### PR TITLE
Add Excel export for model results

### DIFF
--- a/my_forecast_app_v1/requirements.txt
+++ b/my_forecast_app_v1/requirements.txt
@@ -7,3 +7,4 @@ scikit-learn==1.2.2
 statsmodels==0.13.5
 tensorflow==2.12.0  
 gunicorn==21.2.0
+XlsxWriter==3.1.9

--- a/my_forecast_app_v1/templates/plot.html
+++ b/my_forecast_app_v1/templates/plot.html
@@ -14,6 +14,14 @@
         <p><strong>Reales (test):</strong> {{ test_display }}</p>
         <p><strong>Pronosticados:</strong> {{ pred_display }}</p>
         <canvas id="chart" height="100"></canvas>
+        <form method="POST" action="{{ url_for('download_excel') }}" class="mt-3">
+            <input type="hidden" name="model_name" value="{{ model_name }}" />
+            <input type="hidden" name="train_series" value='{{ train_series|tojson }}' />
+            <input type="hidden" name="test_series" value='{{ test_series|tojson }}' />
+            <input type="hidden" name="pred_series" value='{{ pred_series|tojson }}' />
+            <input type="hidden" name="dates" value='{{ dates|tojson }}' />
+            <button type="submit" class="btn btn-primary">Guardar en Excel</button>
+        </form>
     </div>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- allow downloading selected model's data and chart as an Excel file
- add hidden data form and export button on the results page
- include XlsxWriter dependency for Excel generation

## Testing
- `python -m py_compile my_forecast_app_v1/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7c834baec832f961dbc7dcc059843