### PR TITLE
Refine period options and reset form after forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Antes de poder construir o desplegar la aplicación asegúrate de tener:
 
 Al iniciar la aplicación podrás elegir el período de datos descargados desde Yahoo Finance. Las opciones son:
 
-- `1d`
 - `5d`
 - `1mo`
 - `3mo`

--- a/my_forecast_app_v1/app.py
+++ b/my_forecast_app_v1/app.py
@@ -99,25 +99,47 @@ def index():
         formatted_forecasts = {
             model: format_forecast(vals) for model, vals in forecast_values.items()
         }
+
+        period_labels = {
+            "5d": "5 días",
+            "1mo": "1 mes",
+            "3mo": "3 meses",
+            "6mo": "6 meses",
+            "1y": "1 año",
+            "ytd": "Año en curso",
+            "2y": "2 años",
+            "5y": "5 años",
+            "10y": "10 años",
+            "max": "Máx",
+        }
+        display_period = period_labels.get(selected_period, selected_period)
+
         return render_template(
             "index.html",
-            period=selected_period,
             metrics_table=metrics_table,
             forecast_values=formatted_forecasts,
             train_series=train_series,
             test_series=test_series,
             predictions_dict=predictions_dict,
             dates=dates,
+            selected_period=None,
+            selected_test_percent="",
+            display_period=display_period,
+            display_test_percent=test_percent,
         )
     else:
-        # Método GET: solo mostramos el formulario vacío
-        return render_template("index.html")
+        # Método GET: mostramos el formulario con valores por defecto
+        return render_template(
+            "index.html",
+            selected_period="1mo",
+            selected_test_percent=20,
+        )
 
 
 def get_data_from_yahoo(period="1y"):
     """
     Descarga datos de USD/MXN de Yahoo Finance en base a un string de período.
-    Periodos válidos: '1d', '5d', '1mo', '3mo', '6mo', '1y', 'ytd', '2y',
+    Periodos válidos: '5d', '1mo', '3mo', '6mo', '1y', 'ytd', '2y',
     '5y', '10y' y 'max'.
     """
     ticker = "MXN=X"  # El par USD/MXN en Yahoo Finance se identifica como "MXN=X"

--- a/my_forecast_app_v1/templates/index.html
+++ b/my_forecast_app_v1/templates/index.html
@@ -13,22 +13,29 @@
         <form method="POST">
             <label for="period_select">Selecciona el periodo:</label>
             <select name="period_select" id="period_select" class="form-select" style="max-width:300px;">
-                <option value="1d">1 día</option>
-                <option value="5d">5 días</option>
-                <option value="1mo">1 mes</option>
-                <option value="3mo">3 meses</option>
-                <option value="6mo">6 meses</option>
-                <option value="1y">1 año</option>
-                <option value="ytd">Año en curso</option>
-                <option value="2y">2 años</option>
-                <option value="5y">5 años</option>
-                <option value="10y">10 años</option>
-                <option value="max">Máx</option>
+                <option value="" disabled {% if not selected_period %}selected{% endif %}>Selecciona un periodo</option>
+                <option value="5d" {% if selected_period == '5d' %}selected{% endif %}>5 días</option>
+                <option value="1mo" {% if selected_period == '1mo' %}selected{% endif %}>1 mes</option>
+                <option value="3mo" {% if selected_period == '3mo' %}selected{% endif %}>3 meses</option>
+                <option value="6mo" {% if selected_period == '6mo' %}selected{% endif %}>6 meses</option>
+                <option value="1y" {% if selected_period == '1y' %}selected{% endif %}>1 año</option>
+                <option value="ytd" {% if selected_period == 'ytd' %}selected{% endif %}>Año en curso</option>
+                <option value="2y" {% if selected_period == '2y' %}selected{% endif %}>2 años</option>
+                <option value="5y" {% if selected_period == '5y' %}selected{% endif %}>5 años</option>
+                <option value="10y" {% if selected_period == '10y' %}selected{% endif %}>10 años</option>
+                <option value="max" {% if selected_period == 'max' %}selected{% endif %}>Máx</option>
             </select>
             <label for="test_percent" class="mt-2">Porcentaje para testing:</label>
-            <input type="number" name="test_percent" id="test_percent" class="form-control" value="20" min="1" max="80" style="max-width:150px;" />
+            <input type="number" name="test_percent" id="test_percent" class="form-control" value="{{ selected_test_percent }}" min="1" max="80" style="max-width:150px;" />
             <button type="submit" class="btn btn-primary mt-2">Consultar y pronosticar</button>
         </form>
+
+        {% if display_period %}
+            <div class="alert alert-info mt-3">
+                <strong>Última selección:</strong>
+                Periodo: {{ display_period }}, Porcentaje testing: {{ display_test_percent }}%
+            </div>
+        {% endif %}
 
         {% if metrics_table %}
             <h2 class="mt-4">Resultados de métricas</h2>


### PR DESCRIPTION
## Summary
- Remove "1 día" period option and default the dropdown to "1 mes" on first load
- After forecasting, show the last selected period and test percentage while resetting form fields
- Update documentation to reflect new period options

## Testing
- `pytest`
- `python -m py_compile my_forecast_app_v1/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b92047f428832fa68d3c929f3bea91